### PR TITLE
Change `User-Agent` when test

### DIFF
--- a/abejacli/session.py
+++ b/abejacli/session.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from json import JSONDecodeError
 
@@ -9,8 +10,18 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 
+IS_TEST_REQUEST = bool(os.environ.get('IS_TEST_REQUEST', 'False') == 'True')
+
+
 def generate_retry_session():
     session = requests.Session()
+    session.headers.update({
+        'User-Agent': 'abeja-platform-cli/{}'.format(VERSION)
+    })
+    if IS_TEST_REQUEST:
+        session.headers.update({
+            'User-Agent': 'abeja-system-test'
+        })
     retries = Retry(total=5,
                     backoff_factor=1,
                     method_whitelist=('GET', 'POST', 'PUT', 'DELETE', 'PATCH'),
@@ -25,6 +36,10 @@ def generate_user_session(json_content_type=True):
     session.headers.update({
         'User-Agent': 'abeja-platform-cli/{}'.format(VERSION)
     })
+    if IS_TEST_REQUEST:
+        session.headers.update({
+            'User-Agent': 'abeja-system-test'
+        })
     if ABEJA_PLATFORM_USER_ID and ABEJA_PLATFORM_TOKEN:
         session.auth = (ABEJA_PLATFORM_USER_ID, ABEJA_PLATFORM_TOKEN)
     elif PLATFORM_AUTH_TOKEN:

--- a/abejacli/session.py
+++ b/abejacli/session.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 from json import JSONDecodeError
 
@@ -10,18 +9,11 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 
-IS_TEST_REQUEST = bool(os.environ.get('IS_TEST_REQUEST', 'False') == 'True')
-
-
 def generate_retry_session():
     session = requests.Session()
     session.headers.update({
         'User-Agent': 'abeja-platform-cli/{}'.format(VERSION)
     })
-    if IS_TEST_REQUEST:
-        session.headers.update({
-            'User-Agent': 'abeja-system-test'
-        })
     retries = Retry(total=5,
                     backoff_factor=1,
                     method_whitelist=('GET', 'POST', 'PUT', 'DELETE', 'PATCH'),
@@ -36,10 +28,6 @@ def generate_user_session(json_content_type=True):
     session.headers.update({
         'User-Agent': 'abeja-platform-cli/{}'.format(VERSION)
     })
-    if IS_TEST_REQUEST:
-        session.headers.update({
-            'User-Agent': 'abeja-system-test'
-        })
     if ABEJA_PLATFORM_USER_ID and ABEJA_PLATFORM_TOKEN:
         session.auth = (ABEJA_PLATFORM_USER_ID, ABEJA_PLATFORM_TOKEN)
     elif PLATFORM_AUTH_TOKEN:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os
+
+
+os.environ['IS_TEST_REQUEST'] = 'True'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,0 @@
-import os
-
-
-os.environ['IS_TEST_REQUEST'] = 'True'

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,6 @@ from abejacli.config import ABEJA_PLATFORM_USER_ID, ABEJA_PLATFORM_TOKEN, PLATFO
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
-from functools import wraps
 from unittest.mock import patch
 
 
@@ -51,7 +50,6 @@ def _test_generate_user_session(json_content_type=True):
 
 
 def session_decorator(func):
-    @wraps(func)
     def wrapper(*args, **kwargs):
         with patch('abejacli.session.generate_retry_session') as mock_generate_retry_session, \
                 patch('abejacli.session.generate_user_session') as mock_generate_user_session:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,61 @@
+import requests
+from abejacli.config import ABEJA_PLATFORM_USER_ID, ABEJA_PLATFORM_TOKEN, PLATFORM_AUTH_TOKEN
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+from functools import wraps
+from unittest.mock import patch
+
+
+def _test_generate_retry_session():
+    session = requests.Session()
+    session.headers.update({
+        'User-Agent': 'abeja-system-test'
+    })
+
+    retries = Retry(total=5,
+                    backoff_factor=1,
+                    method_whitelist=('GET', 'POST', 'PUT', 'DELETE', 'PATCH'),
+                    status_forcelist=(500, 502, 503, 504),
+                    raise_on_status=False)
+    session.mount('https://', HTTPAdapter(max_retries=retries))
+    return session
+
+
+def _test_generate_user_session(json_content_type=True):
+    session = requests.Session()
+    session.headers.update({
+        'User-Agent': 'abeja-system-test'
+    })
+    if ABEJA_PLATFORM_USER_ID and ABEJA_PLATFORM_TOKEN:
+        session.auth = (ABEJA_PLATFORM_USER_ID, ABEJA_PLATFORM_TOKEN)
+    elif PLATFORM_AUTH_TOKEN:
+        session.headers.update({
+            'Authorization': 'Bearer {}'.format(PLATFORM_AUTH_TOKEN)
+        })
+
+    # Actually, we don't need to set `Content-Type` manually, If we use
+    # `requests.request(url, json=json)`...
+    if json_content_type:
+        session.headers.update({
+            'Content-Type': 'application/json'
+        })
+
+    retries = Retry(total=5,
+                    backoff_factor=1,
+                    method_whitelist=('GET', 'POST', 'PUT', 'DELETE', 'PATCH'),
+                    status_forcelist=(500, 502, 503, 504),
+                    raise_on_status=False)
+    session.mount('https://', HTTPAdapter(max_retries=retries))
+    return session
+
+
+def session_decorator(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with patch('abejacli.session.generate_retry_session') as mock_generate_retry_session, \
+                patch('abejacli.session.generate_user_session') as mock_generate_user_session:
+            mock_generate_retry_session.side_effect = _test_generate_retry_session
+            mock_generate_user_session.side_effect = _test_generate_user_session
+            return func(*args, **kwargs)
+    return wrapper

--- a/tests/integration/abeja_test.py
+++ b/tests/integration/abeja_test.py
@@ -23,6 +23,8 @@ from abejacli.run import (_create_deployment, _create_endpoint, _create_model,
                           _create_deployment_version, _describe_deployment_versions,
                           _download_deployment_version, _delete_deployment_version)
 from backports import tempfile
+from tests import session_decorator
+
 
 TRIGGER_INPUT_DATALAKE_ID = os.environ.get(
     'TRIGGER_INPUT_DATALAKE_ID', '1332934178129')
@@ -34,6 +36,7 @@ DATALAKE_BUCKET_ID = os.environ.get('DATALAKE_BUCKET_ID', '1995386829827')
 
 class AbejaCliTest(unittest.TestCase):
 
+    @session_decorator
     def test_model_deploy(self):
         # create
         # create-model
@@ -149,6 +152,7 @@ class AbejaCliTest(unittest.TestCase):
         r = _delete_model(model_id)
         self.assertIn(model_id, r['message'], "Response (r): {}".format(r))
 
+    @session_decorator
     def test_trigger(self):
         # create
         # create-model
@@ -281,6 +285,7 @@ class AbejaCliTest(unittest.TestCase):
 #    r = _delete_run(deployment_id, run_id)
 #    self.assertIn(run_id, r['message'])
 
+    @session_decorator
     def test_datalake(self):
 
         with tempfile.TemporaryDirectory() as dir_name:
@@ -328,6 +333,7 @@ class AbejaCliTest(unittest.TestCase):
                 # check if all uploaded files are downloaded
                 self.assertTrue(upload_file_id in download_sources)
 
+    @session_decorator
     def test_bucket(self):
 
         with tempfile.TemporaryDirectory() as dir_name:
@@ -366,6 +372,7 @@ class AbejaCliTest(unittest.TestCase):
                 upload_file_id = "/{}".format(upload_file_id)
                 self.assertTrue(upload_file_id in download_sources)
 
+    @session_decorator
     def test_deployment_deploy(self):
         # create
         # create-deployment


### PR DESCRIPTION
Integration testで実際のAPIエンドポイントを叩くが、ログからはそれがテストかユーザーかわからずdeprecatedなエンドポイントの利用実績を調査するのに困ったので、対応。