### PR TITLE
Pass `destination` for retrying bucket upload file

### DIFF
--- a/abejacli/bucket/upload_job.py
+++ b/abejacli/bucket/upload_job.py
@@ -82,6 +82,7 @@ def upload_job(bucket_id, upload_file: UploadBucketFile, report_queue, options):
     except Exception as e:
         options = {
             'source': file_path,
+            'destination': file_id,
             'metadata': metadata,
             'error': 'Failed to upload {} to bucket_id {} (Reason: {})'.format(
                 file_path, bucket_id, e)

--- a/tests/unit/bucket/upload_job_test.py
+++ b/tests/unit/bucket/upload_job_test.py
@@ -146,3 +146,6 @@ class UploadWorkerTest(TestCase):
         self.assertEqual(args[0][0], RAISE_ERROR)
         self.assertEqual(args[0][2], 0)
         self.assertEqual(args[0][3]['source'], UPLOAD_FILE_PATH)
+        self.assertIsNotNone(args[0][3]['destination'])
+        self.assertIn('metadata', args[0][3])
+        self.assertIsNotNone(args[0][3]['error'])

--- a/tests/unit/datalake/upload_job_test.py
+++ b/tests/unit/datalake/upload_job_test.py
@@ -161,3 +161,6 @@ class UploadWorkerTest(TestCase):
         self.assertEqual(args[0][0], RAISE_ERROR)
         self.assertEqual(args[0][2], 0)
         self.assertEqual(args[0][3]['source'], UPLOAD_FILE_PATH)
+        self.assertNotIn('destination', args[0][3])
+        self.assertIn('metadata', args[0][3])
+        self.assertIsNotNone(args[0][3]['error'])


### PR DESCRIPTION
Bucketでファイルアップロード失敗時のRetryにバグがあったので修正しました。必要なパラメータを渡すように変更しています。

## Related Issue
https://github.com/abeja-inc/platform-planning/issues/3204