### PR TITLE
Update training config schema

### DIFF
--- a/abejacli/training/commands.py
+++ b/abejacli/training/commands.py
@@ -981,8 +981,8 @@ def _unarchive_training_model(job_definition_name, model_id):
 # ---------------------------------------------------
 @training.command(name='debug-local', help='Local train commands', context_settings=dict(
     ignore_unknown_options=True, allow_extra_args=True))
-@click.option('-h', '--handler', 'handler', type=str, help='Training handler', required=True)
-@click.option('-i', '--image', 'image', type=str, required=True,
+@click.option('-h', '--handler', 'handler', type=str, help='Training handler', required=False)
+@click.option('-i', '--image', 'image', type=str, required=False,
               callback=convert_to_local_image_callback,
               help='Specify base image name and tag in the "name:tag" format. ex) abeja-inc/all-gpu:19.10')
 @click.option('-o', '--organization_id', '--organization-id', 'organization_id', type=str, required=False,

--- a/abejacli/training/commands.py
+++ b/abejacli/training/commands.py
@@ -158,9 +158,9 @@ def describe_job_definitions(job_definition_name, include_archived, limit, offse
               required=False, multiple=True)
 def create_notebook(notebook_type, instance_type, image, datalakes, buckets, datasets):
     try:
-        params = training_config.read(training_config.create_notebook_schema)
+        config = training_config.read(training_config.create_notebook_schema)
 
-        image = image or params.get('image')
+        image = image or config.get('image')
         if not image:
             raise InvalidConfigException('need to specify image')
 
@@ -168,6 +168,8 @@ def create_notebook(notebook_type, instance_type, image, datalakes, buckets, dat
             'image': image,
             'notebook_type': notebook_type
         }
+
+        instance_type = instance_type or config.get('instance_type')
         if instance_type is not None:
             payload['instance_type'] = instance_type
         if datalakes:
@@ -178,7 +180,7 @@ def create_notebook(notebook_type, instance_type, image, datalakes, buckets, dat
             payload['datasets'] = dict(datasets)
 
         url = "{}/training/definitions/{}/notebooks".format(
-            ORGANIZATION_ENDPOINT, params['name'])
+            ORGANIZATION_ENDPOINT, config['name'])
 
         r = api_post(url, json.dumps(payload))
     except ConfigFileNotFoundError:
@@ -200,11 +202,6 @@ def create_notebook(notebook_type, instance_type, image, datalakes, buckets, dat
 @click.option('-n', '--notebook_id', '--notebook-id', 'notebook_id', type=str, help='notebook id', required=True)
 @click.option('-t', '--notebook-type', type=str, required=False,
               help='Jupyter type. Choose from "notebook" or "lab".')
-@click.option('--instance-type', type=str, required=False,
-              help='Instance Type of the machine where notebook is started. '
-                   'By default, cpu-1 and gpu-1 is used for all-cpu and all-gpu images respectively.')
-@click.option('-i', '--image', 'image', type=str, required=False,
-              help='Specify base image name and tag in the "name:tag" format. ex) abeja-inc/all-gpu:19.10')
 @click.option('--datalake', '--datalakes', 'datalakes', type=str, default=None, required=False, multiple=True,
               help='[Alpha stage option] Datalake channel ID for premount.')
 @click.option('--bucket', '--buckets', 'buckets', type=str, default=None, required=False, multiple=True,
@@ -212,21 +209,13 @@ def create_notebook(notebook_type, instance_type, image, datalakes, buckets, dat
 @click.option('--dataset', '--datasets', 'datasets', type=DATASET_PARAM_STR,
               help='[Alpha stage option] Dataset ID for premount.', default=None,
               required=False, multiple=True)
-def start_notebook(notebook_id, notebook_type, instance_type, image, datalakes, buckets, datasets):
+def start_notebook(notebook_id, notebook_type, datalakes, buckets, datasets):
     try:
         params = training_config.read(training_config.create_notebook_schema)
 
-        image = image or params.get('image')
-        if not image:
-            raise InvalidConfigException('need to specify image')
-
-        payload = {
-            'image': image
-        }
+        payload = dict()
         if notebook_type is not None:
             payload['notebook_type'] = notebook_type
-        if instance_type is not None:
-            payload['instance_type'] = instance_type
         if datalakes:
             payload['datalakes'] = list(datalakes)
         if buckets:
@@ -275,10 +264,10 @@ def create_training_version(description, environment, exclude, datalakes, bucket
 
     archive = None
     try:
-        params = dict(training_config.read(training_config.create_version_schema))
+        config = training_config.read(training_config.create_version_schema)
 
-        handler = params.get('handler')
-        image = params.get('image')
+        handler = config.get('handler')
+        image = config.get('image')
         if not handler or not image:
             raise InvalidConfigException('need to specify handler and image both')
 
@@ -294,7 +283,7 @@ def create_training_version(description, environment, exclude, datalakes, bucket
         if description is not None:
             payload['description'] = description
 
-        environment = {**params.get('environment', {}), **dict(environment)}
+        environment = {**dict(config.get('environment', {})), **dict(environment)}
         if environment:
             payload['environment'] = environment
 
@@ -303,13 +292,13 @@ def create_training_version(description, environment, exclude, datalakes, bucket
         if buckets:
             payload['buckets'] = list(buckets)
 
-        user_exclude_files = params.pop('ignores', [])
+        user_exclude_files = config.pop('ignores', [])
         exclude_files = set(user_exclude_files + DEFAULT_EXCLUDE_FILES + excludes)
 
-        archive = version_archive(params['name'], exclude_files)
+        archive = version_archive(config['name'], exclude_files)
 
         url = "{}/training/definitions/{}/versions".format(
-            ORGANIZATION_ENDPOINT, params['name'])
+            ORGANIZATION_ENDPOINT, config['name'])
 
         r = _create_training_version(url, payload, archive)
     except ConfigFileNotFoundError:
@@ -360,10 +349,10 @@ def _create_training_version(url: str, payload: Dict[str, str], archive):
               help='[Alpha stage option] Datalake bucket ID for premount.')
 def create_training_version_from_git(git_url, git_branch, description, environment, datalakes, buckets):
     try:
-        params = dict(training_config.read(training_config.create_version_schema))
+        config = training_config.read(training_config.create_version_schema)
 
-        handler = params.get('handler')
-        image = params.get('image')
+        handler = config.get('handler')
+        image = config.get('image')
         if not handler or not image:
             raise InvalidConfigException('need to specify handler and image both')
 
@@ -383,7 +372,7 @@ def create_training_version_from_git(git_url, git_branch, description, environme
         if description is not None:
             payload['description'] = description
 
-        environment = {**params.get('environment', {}), **dict(environment)}
+        environment = {**dict(config.get('environment', {})), **dict(environment)}
         if environment:
             payload['environment'] = environment
 
@@ -393,7 +382,7 @@ def create_training_version_from_git(git_url, git_branch, description, environme
             payload['buckets'] = list(buckets)
 
         url = "{}/training/definitions/{}/git/versions".format(
-            ORGANIZATION_ENDPOINT, params['name'])
+            ORGANIZATION_ENDPOINT, config['name'])
 
         r = api_post(url, json.dumps(payload))
     except ConfigFileNotFoundError:
@@ -418,7 +407,7 @@ def create_training_version_from_git(git_url, git_branch, description, environme
               help='Description for the training job, which must be less than or equal to 256 characters.')
 def update_training_version(version, description):
     try:
-        config = training_config.read(training_config.create_version_schema)
+        config = training_config.read(training_config.default_schema)
     except ConfigFileNotFoundError:
         logger.error('training configuration file does not exists.')
         click.echo('training configuration file does not exists.')
@@ -535,10 +524,10 @@ def _get_latest_training_version(name: str):
 def create_training_job(version, environment, params, instance_type, description,
                         datasets, datalakes, buckets, dataset_premounted):
     try:
-        config_data = training_config.read(training_config.default_schema)
+        config = training_config.read(training_config.create_job_schema)
         if version is None:
             try:
-                version = _get_latest_training_version(config_data['name'])
+                version = _get_latest_training_version(config['name'])
             except ResourceNotFound:
                 logger.error('there is no available training versions.')
                 click.echo(
@@ -546,17 +535,18 @@ def create_training_job(version, environment, params, instance_type, description
                 sys.exit(ERROR_EXITCODE)
 
         url = "{}/training/definitions/{}/versions/{}/jobs".format(
-            ORGANIZATION_ENDPOINT, config_data['name'], version)
+            ORGANIZATION_ENDPOINT, config['name'], version)
 
         environment = dict(environment) or dict(params)
-        env_vars = {**dict(config_data.get('environment', {})), **environment}
+        env_vars = {**dict(config.get('environment', {})), **environment}
 
-        _datasets = dict(config_data.get('datasets', {}))
+        _datasets = dict(config.get('datasets', {}))
         datasets = {**_datasets, **dict(datasets)}
 
         data = {}
         if env_vars:
             data['environment'] = env_vars
+        instance_type = instance_type or config.get('instance_type')
         if instance_type is not None:
             data['instance_type'] = instance_type
         if datasets:
@@ -1024,7 +1014,12 @@ def debug_local(
         handler, image, organization_id, datasets, environment, volume,
         no_cache, quiet, v1, runtime=None, build_only=False):
     try:
-        config = training_config.read(training_config.default_schema)
+        config = training_config.read(training_config.debug_schema)
+
+        handler = handler or config.get('handler')
+        image = image or config.get('image')
+        if not handler or not image:
+            raise InvalidConfigException('need to specify handler and image both')
 
         datasets = {**dict(config.get('datasets', {})), **dict(datasets)}
 
@@ -1055,7 +1050,8 @@ def debug_local(
                    'this value is set as an environment variable named `ABEJA_ORGANIZATION_ID`.',
               callback=__try_get_organization_id)
 @click.option('--name', 'name', type=str, help='Training Job Definition Name', required=True)
-@click.option('--version', 'version', type=str, help='Training Job Definition Version', required=True)
+@click.option('--version', 'version', type=str, required=False,
+              help='Job definition version. By default, latest version is used')
 @click.option('--description', 'description', type=str, help='Training Job description', required=False)
 @click.option('-d', '--datasets', type=DATASET_PARAM_STR, help='Datasets name', default=None,
               required=False, multiple=True)
@@ -1075,7 +1071,15 @@ def debug_local(
     help='Read Configuration from PATH. By default read from `{}`'.format(CONFIGFILE_NAME))
 def train_local(organization_id, name, version, description, datasets, environment, volume, v1, runtime=None):
     try:
-        config = training_config.read(training_config.default_schema)
+        config = training_config.read(training_config.local_schema)
+        if version is None:
+            try:
+                version = _get_latest_training_version(config['name'])
+            except ResourceNotFound:
+                logger.error('there is no available training versions.')
+                click.echo(
+                    'there is no available training versions. please create training version first.')
+                sys.exit(ERROR_EXITCODE)
 
         job_definition_version = _describe_training_version(name, version)
         version_datasets = job_definition_version.get('datasets')
@@ -1085,9 +1089,9 @@ def train_local(organization_id, name, version, description, datasets, environme
         if not version_environment:
             version_environment = {}
 
-        datasets = {**version_datasets, **dict(**config.get('datasets', {})), **dict(datasets)}
+        datasets = {**version_datasets, **dict(config.get('datasets', {})), **dict(datasets)}
 
-        environment = {**version_environment, **dict(**config.get('environment', {})), **dict(environment)}
+        environment = {**version_environment, **dict(config.get('environment', {})), **dict(environment)}
 
         volume = build_volumes(volume) if volume else {}
 

--- a/abejacli/training/commands.py
+++ b/abejacli/training/commands.py
@@ -1050,8 +1050,7 @@ def debug_local(
                    'this value is set as an environment variable named `ABEJA_ORGANIZATION_ID`.',
               callback=__try_get_organization_id)
 @click.option('--name', 'name', type=str, help='Training Job Definition Name', required=True)
-@click.option('--version', 'version', type=str, required=False,
-              help='Job definition version. By default, latest version is used')
+@click.option('--version', 'version', type=str, help='Training Job Definition Version', required=True)
 @click.option('--description', 'description', type=str, help='Training Job description', required=False)
 @click.option('-d', '--datasets', type=DATASET_PARAM_STR, help='Datasets name', default=None,
               required=False, multiple=True)
@@ -1072,14 +1071,6 @@ def debug_local(
 def train_local(organization_id, name, version, description, datasets, environment, volume, v1, runtime=None):
     try:
         config = training_config.read(training_config.local_schema)
-        if version is None:
-            try:
-                version = _get_latest_training_version(config['name'])
-            except ResourceNotFound:
-                logger.error('there is no available training versions.')
-                click.echo(
-                    'there is no available training versions. please create training version first.')
-                sys.exit(ERROR_EXITCODE)
 
         job_definition_version = _describe_training_version(name, version)
         version_datasets = job_definition_version.get('datasets')

--- a/tests/unit/training/commands_test.py
+++ b/tests/unit/training/commands_test.py
@@ -98,51 +98,100 @@ def test_update_training_version(req_mock, runner):
     'cmd,additional_config,expected_payload',
     [
         ([],
-         {},
          {
-             'notebook_type': 'notebook'
-        }),
-        (['-t', 'lab'],
-         {},
-         {
-             'notebook_type': 'lab'
-        }),
-        (['--instance-type', 'gpu-1'],
-         {},
+             'image': 'abeja-inc/all-gpu:19.10'
+         },
          {
              'notebook_type': 'notebook',
+             'image': 'abeja-inc/all-gpu:19.10'
+        }),
+        (['-t', 'lab'],
+         {
+             'image': 'abeja-inc/all-gpu:19.10'
+         },
+         {
+             'notebook_type': 'lab',
+             'image': 'abeja-inc/all-gpu:19.10'
+        }),
+        (['--instance-type', 'gpu-1'],
+         {
+             'image': 'abeja-inc/all-gpu:19.10'
+         },
+         {
+             'notebook_type': 'notebook',
+             'image': 'abeja-inc/all-gpu:19.10',
              'instance_type': 'gpu-1'
         }),
         (['--image', 'abeja-inc/all-gpu:19.10'],
          {},
          {
+             'notebook_type': 'notebook',
              'image': 'abeja-inc/all-gpu:19.10'
         }),
         (['--datalake', '1234567890123'],
-         {},
+         {
+             'image': 'abeja-inc/all-gpu:19.10'
+         },
          {
              'notebook_type': 'notebook',
+             'image': 'abeja-inc/all-gpu:19.10',
              'datalakes': ['1234567890123']
         }),
         (['--bucket', '1234567890123'],
-         {},
+         {
+             'image': 'abeja-inc/all-gpu:19.10'
+         },
          {
              'notebook_type': 'notebook',
+             'image': 'abeja-inc/all-gpu:19.10',
              'buckets': ['1234567890123']
         }),
         (['--datalake', '1234567890123', '--bucket', '1234567890123'],
-         {},
+         {
+             'image': 'abeja-inc/all-gpu:19.10'
+         },
          {
              'notebook_type': 'notebook',
+             'image': 'abeja-inc/all-gpu:19.10',
              'datalakes': ['1234567890123'],
              'buckets': ['1234567890123']
         }),
         (['--dataset', 'train:1600000000000'],
-         {},
+         {
+             'image': 'abeja-inc/all-gpu:19.10'
+         },
          {
              'notebook_type': 'notebook',
+             'image': 'abeja-inc/all-gpu:19.10',
              'datasets': {'train': '1600000000000'}
-        })
+        }),
+        (['--image', 'abeja-inc/all-gpu:18.10'],
+         {
+             'image': 'abeja-inc/all-gpu:19.10'
+         },
+         {
+             'notebook_type': 'notebook',
+             'image': 'abeja-inc/all-gpu:18.10'
+        }),
+        ([],
+         {
+             'image': 'abeja-inc/all-gpu:19.10',
+             'instance_type': 'gpu-1'
+         },
+         {
+             'notebook_type': 'notebook',
+             'image': 'abeja-inc/all-gpu:19.10',
+             'instance_type': 'gpu-1'
+        }),
+        ([],
+         {
+             'image': 'abeja-inc/all-gpu:19.10',
+             'dummy': 'dummy'
+         },
+         {
+             'notebook_type': 'notebook',
+             'image': 'abeja-inc/all-gpu:19.10'
+        }),
     ]
 )
 @patch('abejacli.training.commands.CONFIG', TEST_CONFIG)
@@ -150,8 +199,7 @@ def test_update_training_version(req_mock, runner):
 def test_create_notebook(
         req_mock, runner, cmd, additional_config, expected_payload):
     config_data = {
-        'name': 'training-1',
-        'image': 'abeja-inc/all-cpu:18.10'
+        'name': 'training-1'
     }
     config_data = {**config_data, **additional_config}
     with open(abejacli.training.CONFIGFILE_NAME, 'w') as configfile:
@@ -174,51 +222,38 @@ def test_create_notebook(
     [
         (['-n', '9876543210987'],
          {},
-         {
-            'image': 'abeja-inc/all-cpu:18.10'
-        }),
-        (['-n', '9876543210987', '--instance-type', 'gpu-1'],
-         {},
-         {
-            'image': 'abeja-inc/all-cpu:18.10',
-            'instance_type': 'gpu-1'
-        }),
-        (['-n', '9876543210987', '--image', 'abeja-inc/all-gpu:19.10'],
-         {},
-         {
-            'image': 'abeja-inc/all-gpu:19.10'
-        }),
+         {}),
         (['-n', '9876543210987', '-t', 'lab'],
          {},
          {
-            'image': 'abeja-inc/all-cpu:18.10',
             'notebook_type': 'lab'
         }),
         (['-n', '9876543210987', '--datalake', '1234567890123'],
          {},
          {
-            'image': 'abeja-inc/all-cpu:18.10',
             'datalakes': ['1234567890123']
         }),
         (['-n', '9876543210987', '--bucket', '1234567890123'],
          {},
          {
-            'image': 'abeja-inc/all-cpu:18.10',
             'buckets': ['1234567890123']
         }),
         (['-n', '9876543210987', '--datalake', '1234567890123', '--bucket', '1234567890123'],
          {},
          {
-            'image': 'abeja-inc/all-cpu:18.10',
             'datalakes': ['1234567890123'],
             'buckets': ['1234567890123']
         }),
         (['-n', '9876543210987', '--dataset', 'train:1600000000000'],
          {},
          {
-            'image': 'abeja-inc/all-cpu:18.10',
             'datasets': {'train': '1600000000000'}
-        })
+        }),
+        (['-n', '9876543210987'],
+         {
+             'dummy': 'dummy'
+         },
+         {}),
     ]
 )
 @patch('abejacli.training.commands.CONFIG', TEST_CONFIG)
@@ -227,8 +262,7 @@ def test_start_notebook(
         req_mock, runner, cmd, additional_config, expected_payload):
     notebook_id = '9876543210987'
     config_data = {
-        'name': 'training-1',
-        'image': 'abeja-inc/all-cpu:18.10'
+        'name': 'training-1'
     }
     config_data = {**config_data, **additional_config}
     with open(abejacli.training.CONFIGFILE_NAME, 'w') as configfile:
@@ -523,7 +557,7 @@ def test_create_training_version_from_git(
          {},
          {
              'description': 'dummy description'
-        }),
+         }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32', '--datasets', 'train:1600000000000'],
          {},
@@ -532,45 +566,45 @@ def test_create_training_version_from_git(
              'datasets': {'train': '1600000000000'},
              'dataset_premounted': False,
              'environment': {'BATCH_SIZE': '32'}
-        }),
+         }),
         (['--version', '1', '--description', 'dummy description'],
          {
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-        },
-            {
+         },
+         {
              'description': 'dummy description',
              'datasets': {'train': '1600000000000'},
              'dataset_premounted': False,
              'environment': {'key1': 'value1', 'key2': 'value2'}
-        }),
+         }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32'],
          {
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-        },
-            {
+         },
+         {
              'description': 'dummy description',
              'datasets': {'train': '1600000000000'},
              'dataset_premounted': False,
              'environment': {'key1': 'value1', 'key2': 'value2', 'BATCH_SIZE': '32'}
-        }),
+         }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32', '--datasets', 'train:1600000000001'],
          {
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-        },
-            {
+         },
+         {
              'description': 'dummy description',
              'datasets': {'train': '1600000000001'},
              'dataset_premounted': False,
              'environment': {'key1': 'value1', 'key2': 'value2', 'BATCH_SIZE': '32'}
-        }),
+         }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32', '--datasets', 'val:1600000000001',
           '--datasets', 'test:1600000000002'],
@@ -578,13 +612,13 @@ def test_create_training_version_from_git(
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-        },
-            {
+         },
+         {
              'description': 'dummy description',
              'datasets': {'train': '1600000000000', 'val': '1600000000001', 'test': '1600000000002'},
              'dataset_premounted': False,
              'environment': {'key1': 'value1', 'key2': 'value2', 'BATCH_SIZE': '32'}
-        }),
+         }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32', '--datasets', 'val:1600000000001',
           '--datasets', 'test:1600000000002', '--instance-type', 'cpu-4'],
@@ -592,14 +626,14 @@ def test_create_training_version_from_git(
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-        },
-            {
+         },
+         {
              'description': 'dummy description',
              'datasets': {'train': '1600000000000', 'val': '1600000000001', 'test': '1600000000002'},
              'dataset_premounted': False,
              'environment': {'key1': 'value1', 'key2': 'value2', 'BATCH_SIZE': '32'},
              'instance_type': 'cpu-4'
-        }),
+         }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32', '--datasets', 'val:1600000000001',
           '--datasets', 'test:1600000000002', '--instance-type', 'cpu-4',
@@ -608,26 +642,26 @@ def test_create_training_version_from_git(
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-        },
-            {
+         },
+         {
              'description': 'dummy description',
              'datasets': {'train': '1600000000000', 'val': '1600000000001', 'test': '1600000000002'},
              'dataset_premounted': True,
              'environment': {'key1': 'value1', 'key2': 'value2', 'BATCH_SIZE': '32'},
              'instance_type': 'cpu-4'
-        }),
+         }),
         (['--version', '1', '--description', 'dummy description', '--datalake', '1234567890123'],
          {},
          {
              'description': 'dummy description',
              'datalakes': ['1234567890123']
-        }),
+         }),
         (['--version', '1', '--description', 'dummy description', '--bucket', '2345678901234'],
          {},
          {
              'description': 'dummy description',
              'buckets': ['2345678901234']
-        }),
+         }),
         (['--version', '1', '--description', 'dummy description',
           '--datalake', '1234567890123', '--bucket', '2345678901234'],
          {},
@@ -635,16 +669,28 @@ def test_create_training_version_from_git(
              'description': 'dummy description',
              'datalakes': ['1234567890123'],
              'buckets': ['2345678901234']
-        })
+         }),
+        (['--version', '1'],
+         {
+             'instance_type': 'gpu-1'
+         },
+         {
+             'instance_type': 'gpu-1'
+         }),
+        (['--version', '1', '--instance-type', 'cpu-4'],
+         {
+             'instance_type': 'gpu-1'
+         },
+         {
+             'instance_type': 'cpu-4'
+         }),
     ]
 )
 @patch('abejacli.training.commands.CONFIG', TEST_CONFIG)
 @patch('abejacli.training.CONFIGFILE_NAME', get_tmp_training_file_name())
 def test_create_training_job(req_mock, runner, cmd, additional_config, expected_payload):
     config_data = {
-        'name': 'training-1',
-        'handler': 'train:handler',
-        'image': 'abeja-inc/all-cpu:18.10'
+        'name': 'training-1'
     }
     config_data = {**config_data, **additional_config}
     with open(abejacli.training.CONFIGFILE_NAME, 'w') as configfile:

--- a/tests/unit/training/commands_test.py
+++ b/tests/unit/training/commands_test.py
@@ -100,24 +100,24 @@ def test_update_training_version(req_mock, runner):
         ([],
          {
              'image': 'abeja-inc/all-gpu:19.10'
-         },
-         {
+        },
+            {
              'notebook_type': 'notebook',
              'image': 'abeja-inc/all-gpu:19.10'
         }),
         (['-t', 'lab'],
          {
              'image': 'abeja-inc/all-gpu:19.10'
-         },
-         {
+        },
+            {
              'notebook_type': 'lab',
              'image': 'abeja-inc/all-gpu:19.10'
         }),
         (['--instance-type', 'gpu-1'],
          {
              'image': 'abeja-inc/all-gpu:19.10'
-         },
-         {
+        },
+            {
              'notebook_type': 'notebook',
              'image': 'abeja-inc/all-gpu:19.10',
              'instance_type': 'gpu-1'
@@ -131,8 +131,8 @@ def test_update_training_version(req_mock, runner):
         (['--datalake', '1234567890123'],
          {
              'image': 'abeja-inc/all-gpu:19.10'
-         },
-         {
+        },
+            {
              'notebook_type': 'notebook',
              'image': 'abeja-inc/all-gpu:19.10',
              'datalakes': ['1234567890123']
@@ -140,8 +140,8 @@ def test_update_training_version(req_mock, runner):
         (['--bucket', '1234567890123'],
          {
              'image': 'abeja-inc/all-gpu:19.10'
-         },
-         {
+        },
+            {
              'notebook_type': 'notebook',
              'image': 'abeja-inc/all-gpu:19.10',
              'buckets': ['1234567890123']
@@ -149,8 +149,8 @@ def test_update_training_version(req_mock, runner):
         (['--datalake', '1234567890123', '--bucket', '1234567890123'],
          {
              'image': 'abeja-inc/all-gpu:19.10'
-         },
-         {
+        },
+            {
              'notebook_type': 'notebook',
              'image': 'abeja-inc/all-gpu:19.10',
              'datalakes': ['1234567890123'],
@@ -159,8 +159,8 @@ def test_update_training_version(req_mock, runner):
         (['--dataset', 'train:1600000000000'],
          {
              'image': 'abeja-inc/all-gpu:19.10'
-         },
-         {
+        },
+            {
              'notebook_type': 'notebook',
              'image': 'abeja-inc/all-gpu:19.10',
              'datasets': {'train': '1600000000000'}
@@ -168,8 +168,8 @@ def test_update_training_version(req_mock, runner):
         (['--image', 'abeja-inc/all-gpu:18.10'],
          {
              'image': 'abeja-inc/all-gpu:19.10'
-         },
-         {
+        },
+            {
              'notebook_type': 'notebook',
              'image': 'abeja-inc/all-gpu:18.10'
         }),
@@ -177,8 +177,8 @@ def test_update_training_version(req_mock, runner):
          {
              'image': 'abeja-inc/all-gpu:19.10',
              'instance_type': 'gpu-1'
-         },
-         {
+        },
+            {
              'notebook_type': 'notebook',
              'image': 'abeja-inc/all-gpu:19.10',
              'instance_type': 'gpu-1'
@@ -187,8 +187,8 @@ def test_update_training_version(req_mock, runner):
          {
              'image': 'abeja-inc/all-gpu:19.10',
              'dummy': 'dummy'
-         },
-         {
+        },
+            {
              'notebook_type': 'notebook',
              'image': 'abeja-inc/all-gpu:19.10'
         }),
@@ -252,8 +252,8 @@ def test_create_notebook(
         (['-n', '9876543210987'],
          {
              'dummy': 'dummy'
-         },
-         {}),
+        },
+            {}),
     ]
 )
 @patch('abejacli.training.commands.CONFIG', TEST_CONFIG)
@@ -557,7 +557,7 @@ def test_create_training_version_from_git(
          {},
          {
              'description': 'dummy description'
-         }),
+        }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32', '--datasets', 'train:1600000000000'],
          {},
@@ -566,45 +566,45 @@ def test_create_training_version_from_git(
              'datasets': {'train': '1600000000000'},
              'dataset_premounted': False,
              'environment': {'BATCH_SIZE': '32'}
-         }),
+        }),
         (['--version', '1', '--description', 'dummy description'],
          {
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-         },
-         {
+        },
+            {
              'description': 'dummy description',
              'datasets': {'train': '1600000000000'},
              'dataset_premounted': False,
              'environment': {'key1': 'value1', 'key2': 'value2'}
-         }),
+        }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32'],
          {
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-         },
-         {
+        },
+            {
              'description': 'dummy description',
              'datasets': {'train': '1600000000000'},
              'dataset_premounted': False,
              'environment': {'key1': 'value1', 'key2': 'value2', 'BATCH_SIZE': '32'}
-         }),
+        }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32', '--datasets', 'train:1600000000001'],
          {
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-         },
-         {
+        },
+            {
              'description': 'dummy description',
              'datasets': {'train': '1600000000001'},
              'dataset_premounted': False,
              'environment': {'key1': 'value1', 'key2': 'value2', 'BATCH_SIZE': '32'}
-         }),
+        }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32', '--datasets', 'val:1600000000001',
           '--datasets', 'test:1600000000002'],
@@ -612,13 +612,13 @@ def test_create_training_version_from_git(
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-         },
-         {
+        },
+            {
              'description': 'dummy description',
              'datasets': {'train': '1600000000000', 'val': '1600000000001', 'test': '1600000000002'},
              'dataset_premounted': False,
              'environment': {'key1': 'value1', 'key2': 'value2', 'BATCH_SIZE': '32'}
-         }),
+        }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32', '--datasets', 'val:1600000000001',
           '--datasets', 'test:1600000000002', '--instance-type', 'cpu-4'],
@@ -626,14 +626,14 @@ def test_create_training_version_from_git(
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-         },
-         {
+        },
+            {
              'description': 'dummy description',
              'datasets': {'train': '1600000000000', 'val': '1600000000001', 'test': '1600000000002'},
              'dataset_premounted': False,
              'environment': {'key1': 'value1', 'key2': 'value2', 'BATCH_SIZE': '32'},
              'instance_type': 'cpu-4'
-         }),
+        }),
         (['--version', '1', '--description', 'dummy description',
           '--environment', 'BATCH_SIZE:32', '--datasets', 'val:1600000000001',
           '--datasets', 'test:1600000000002', '--instance-type', 'cpu-4',
@@ -642,26 +642,26 @@ def test_create_training_version_from_git(
              'datasets': {'train': '1600000000000'},
              'environment': {'key1': 'value1', 'key2': 'value2'},
              'params': {'key9': 'value9'}
-         },
-         {
+        },
+            {
              'description': 'dummy description',
              'datasets': {'train': '1600000000000', 'val': '1600000000001', 'test': '1600000000002'},
              'dataset_premounted': True,
              'environment': {'key1': 'value1', 'key2': 'value2', 'BATCH_SIZE': '32'},
              'instance_type': 'cpu-4'
-         }),
+        }),
         (['--version', '1', '--description', 'dummy description', '--datalake', '1234567890123'],
          {},
          {
              'description': 'dummy description',
              'datalakes': ['1234567890123']
-         }),
+        }),
         (['--version', '1', '--description', 'dummy description', '--bucket', '2345678901234'],
          {},
          {
              'description': 'dummy description',
              'buckets': ['2345678901234']
-         }),
+        }),
         (['--version', '1', '--description', 'dummy description',
           '--datalake', '1234567890123', '--bucket', '2345678901234'],
          {},
@@ -669,21 +669,21 @@ def test_create_training_version_from_git(
              'description': 'dummy description',
              'datalakes': ['1234567890123'],
              'buckets': ['2345678901234']
-         }),
+        }),
         (['--version', '1'],
          {
              'instance_type': 'gpu-1'
-         },
-         {
+        },
+            {
              'instance_type': 'gpu-1'
-         }),
+        }),
         (['--version', '1', '--instance-type', 'cpu-4'],
          {
              'instance_type': 'gpu-1'
-         },
-         {
+        },
+            {
              'instance_type': 'cpu-4'
-         }),
+        }),
     ]
 )
 @patch('abejacli.training.commands.CONFIG', TEST_CONFIG)

--- a/tests/unit/training/training_test.py
+++ b/tests/unit/training/training_test.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from abejacli.training import TrainingConfig, default_schema
+from abejacli.training import TrainingConfig, create_version_schema
 
 
 @pytest.fixture
@@ -32,7 +32,7 @@ class TestTrainingConfig:
         config = TrainingConfig()
         config._load_config = MagicMock(
             return_value=training_configuration)
-        res = config.read(default_schema)
+        res = config.read(create_version_schema)
         assert 'environment' in res
         for param in res['environment'].values():
             assert param is None or type(param) == str


### PR DESCRIPTION
Training config schemaを実体に合うように修正しました。
後方互換性はあります。

## Changes
- `debug-local`, `local-run`, `create-job`, `create-version`, `create-notebook` の実体にあうように対応するschemaのvalidationを更新
- `training.yaml` のcerberus validationで `allow_unknown=True` を設定
- `instance_type` を `training.yaml` で指定できるように修正
- 各種バグフィックス

## Related Issue
https://github.com/abeja-inc/platform-planning/issues/2995