### PR TITLE
Relax the restriction of specifying `name` on `train-local`

### DIFF
--- a/abejacli/training/commands.py
+++ b/abejacli/training/commands.py
@@ -1049,7 +1049,7 @@ def debug_local(
               help='Organization ID, organization_id of current credential organization is used by default. '
                    'this value is set as an environment variable named `ABEJA_ORGANIZATION_ID`.',
               callback=__try_get_organization_id)
-@click.option('--name', 'name', type=str, help='Training Job Definition Name', required=True)
+@click.option('--name', 'name', type=str, help='Training Job Definition Name', required=False)
 @click.option('--version', 'version', type=str, help='Training Job Definition Version', required=True)
 @click.option('--description', 'description', type=str, help='Training Job description', required=False)
 @click.option('-d', '--datasets', type=DATASET_PARAM_STR, help='Datasets name', default=None,
@@ -1079,6 +1079,10 @@ def train_local(organization_id, name, version, description, datasets, environme
         version_environment = job_definition_version.get('environment')
         if not version_environment:
             version_environment = {}
+
+        name = name or config['name']
+        if not name:
+            raise InvalidConfigException('need to specify name')
 
         datasets = {**version_datasets, **dict(config.get('datasets', {})), **dict(datasets)}
 

--- a/tests/unit/training/commands_test.py
+++ b/tests/unit/training/commands_test.py
@@ -990,6 +990,7 @@ def test_train_local_environment(mock_train_local, mock_get_organization_id, run
     assert r.exit_code == 0, r.output
     mock_get_organization_id.assert_called_once_with()
     args = mock_train_local.call_args[1]
+    assert args['job_definition_name'] == 'training_def_version_1'
     expect_environment = {
         'param1': 'value1',
         'param2': 'value2',
@@ -998,6 +999,21 @@ def test_train_local_environment(mock_train_local, mock_get_organization_id, run
         'foo': 'bar'
     }
     assert args['environment'] == expect_environment
+
+    # Test without `--name`
+    url = "{}/training/definitions/{}/versions/{}".format(
+        ORGANIZATION_ENDPOINT, 'training-1', 1)
+    req_mock.register_uri(
+        'GET', url,
+        json=version_info)
+    cmd = [
+        '--version', '1',
+        '--config', abejacli.training.CONFIGFILE_NAME,
+    ]
+    r = runner.invoke(train_local, cmd)
+    assert r.exit_code == 0, r.output
+    args = mock_train_local.call_args[1]
+    assert args['job_definition_name'] == 'training-1'
 
 # Job definitions
 


### PR DESCRIPTION
`train-local` で `--name` が必須だが、configファイルにある場合はそちらから補えるように変更。

## Related Issue
https://github.com/abeja-inc/platform-planning/issues/3299