### PR TITLE
fix a duplicate short hand options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ test_step: &test_step
   - run:
       name: Install Dependencies
       command: |
-        pip install --user poetry
+        pip install --user poetry==1.0.9
         poetry env use ${ABEJA_CLI_PYTHON_VERSION}
         poetry install
   - run:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 NUM_TEST_PROCESS ?= auto
+FMT_TARGET ?= .
 
 .PHONY: build install clean dist uninstall test prepare_ci integration_test lint fmt release
 
@@ -26,10 +27,10 @@ lint: check-fmt
 	poetry run flake8 abejacli tests --max-line-length=120 --max-complexity=25 --ignore E402,E121
 
 fmt:
-	poetry run isort -rc -sl .
-	poetry run autopep8 -i -r abejacli tests --max-line-length=120 --exclude=abejacli/template/*
-	poetry run autoflake -i -r abejacli tests --remove-all-unused-imports --remove-unused-variables
-	poetry run isort -rc -m 3 .
+	poetry run isort -rc -sl $(FMT_TARGET)
+	poetry run autopep8 -i -r --max-line-length=120 --exclude=abejacli/template/* $(FMT_TARGET)
+	poetry run autoflake -i -r --remove-all-unused-imports --remove-unused-variables $(FMT_TARGET)
+	poetry run isort -rc -m 3 $(FMT_TARGET)
 
 check-fmt:
 	poetry run isort --check-only .

--- a/abejacli/training/commands.py
+++ b/abejacli/training/commands.py
@@ -272,7 +272,7 @@ def start_notebook(job_definition_name, notebook_id, notebook_type, datalakes, b
               help='[Alpha stage option] Datalake channel ID for premount.')
 @click.option('--bucket', '--buckets', 'buckets', type=str, default=None, required=False, multiple=True,
               help='[Alpha stage option] Datalake bucket ID for premount.')
-@click.option('-d', '--dataset', '--datasets', 'datasets', type=DATASET_PARAM_STR,
+@click.option('--dataset', '--datasets', 'datasets', type=DATASET_PARAM_STR,
               help='Datasets name', default=None,
               required=False, multiple=True)
 @click.option('--dataset-premounted', is_flag=True, type=bool, required=False,
@@ -384,7 +384,7 @@ def _create_training_version(url: str, payload: Dict[str, str], archive):
               help='[Alpha stage option] Datalake channel ID for premount.')
 @click.option('--bucket', '--buckets', 'buckets', type=str, default=None, required=False, multiple=True,
               help='[Alpha stage option] Datalake bucket ID for premount.')
-@click.option('-d', '--dataset', '--datasets', 'datasets', type=DATASET_PARAM_STR,
+@click.option('--dataset', '--datasets', 'datasets', type=DATASET_PARAM_STR,
               help='Datasets name', default=None,
               required=False, multiple=True)
 @click.option('--dataset-premounted', is_flag=True, type=bool, required=False,
@@ -563,7 +563,7 @@ def _get_latest_training_version(name: str):
                    'By default, cpu-1 and gpu-1 is used for all-cpu and all-gpu images respectively.')
 @click.option('--description', type=str, required=False,
               help='Description for the training job, which must be less than or equal to 256 characters.')
-@click.option('-d', '--dataset', '--datasets', 'datasets', type=DATASET_PARAM_STR,
+@click.option('--dataset', '--datasets', 'datasets', type=DATASET_PARAM_STR,
               help='Datasets name', default=None,
               required=False, multiple=True)
 @click.option('--datalake', '--datalakes', 'datalakes', type=str, default=None, required=False, multiple=True,
@@ -1110,7 +1110,7 @@ def _unarchive_training_model(job_definition_name, model_id):
               help='Organization ID, organization_id of current credential organization is used by default. '
                    'this value is set as an environment variable named `ABEJA_ORGANIZATION_ID`.',
               callback=__try_get_organization_id)
-@click.option('-d', '--datasets', type=DATASET_PARAM_STR, help='Datasets name', default=None,
+@click.option('--datasets', type=DATASET_PARAM_STR, help='Datasets name', default=None,
               required=False, multiple=True)
 @click.option('-e', '--environment', type=ENVIRONMENT_STR, help='Environment variables', default=None,
               required=False, multiple=True)
@@ -1180,8 +1180,8 @@ def debug_local(
               callback=__try_get_organization_id)
 @click.option('--name', 'name', type=str, help='Training Job Definition Name', required=False)
 @click.option('--version', 'version', type=str, help='Training Job Definition Version', required=True)
-@click.option('--description', 'description', type=str, help='Training Job description', required=False)
-@click.option('-d', '--datasets', type=DATASET_PARAM_STR, help='Datasets name', default=None,
+@click.option('-d', '--description', 'description', type=str, help='Training Job description', required=False)
+@click.option('--datasets', type=DATASET_PARAM_STR, help='Datasets name', default=None,
               required=False, multiple=True)
 @click.option('-e', '--environment', type=ENVIRONMENT_STR, help='Environment variables', default=None,
               required=False, multiple=True)


### PR DESCRIPTION
ちょっと迷ったけど、 training サブコマンド内では統一して
description のショートハンドオプションを `-d`
としました。

あと、全体的にざっと眺めたけど、他にはショートハンドオプションが重複しているものはなさそうでした。
（[download_job_result](https://github.com/abeja-inc/abeja-platform-cli/blob/develop/abejacli/training/commands.py#L670-L674) の `-jd` は斬新だな、と思ったけど）