### PR TITLE
add shorthand option for description on create-job command

### DIFF
--- a/abejacli/training/commands.py
+++ b/abejacli/training/commands.py
@@ -561,7 +561,7 @@ def _get_latest_training_version(name: str):
 @click.option('--instance-type', type=str, required=False,
               help='Instance Type of the machine where training job is executed. '
                    'By default, cpu-1 and gpu-1 is used for all-cpu and all-gpu images respectively.')
-@click.option('--description', type=str, required=False,
+@click.option('-d', '--description', type=str, required=False,
               help='Description for the training job, which must be less than or equal to 256 characters.')
 @click.option('--dataset', '--datasets', 'datasets', type=DATASET_PARAM_STR,
               help='Datasets name', default=None,


### PR DESCRIPTION
ドキュメント書いてたら、 `create-job` コマンドで `--datasets` から `-d` オプション削っただけで、 `--description` に追加してないことに気づいたので追加。

軽微な修正なので、 CI が通ったらセルフマージします。