### PR TITLE
use matrix setting for ci each python version

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -13,6 +13,10 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+      max-parallel: 4
 
     steps:
       - name: Checkout code
@@ -21,7 +25,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: ${{ matrix.python-version }}
           architecture: 'x64'
 
       - name: Install dependencies


### PR DESCRIPTION
https://github.com/abeja-inc/abeja-platform-cli/pull/36#discussion_r859395854

ビルドマトリックスを使って複数の Python バージョンで CI するようにしました。