### PR TITLE
fix api url for integration test

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -60,7 +60,7 @@ jobs:
           echo "DATALAKE_BUCKET_ID=1995371681794" >> $GITHUB_ENV
           echo "TRIGGER_INPUT_DATALAKE_ID=2054929723742" >> $GITHUB_ENV
           echo "TRIGGER_OUTPUT_DATALAKE_ID=2054929811807" >> $GITHUB_ENV
-          echo "ABEJA_API_URL=https://api.dev.abeja.io" >> $GITHUB_ENV
+          echo "ABEJA_API_URL=https://api.abeja.io" >> $GITHUB_ENV
         env:
           PLATFORM_USER_ID_PROD: ${{ secrets.PLATFORM_USER_ID_PROD }}
           PLATFORM_USER_TOKEN_PROD: ${{ secrets.PLATFORM_USER_TOKEN_PROD }}


### PR DESCRIPTION
https://github.com/abeja-inc/abeja-platform-cli/actions/runs/2255787366
リリースビルドの Integration Test で 403 エラー。
ABEJA_API_URL が dev 環境用のままだったので prod 環境用に修正。。。
Github Actions の設定修正のみなので、CI 通ったらセルフマージします。。