### PR TITLE
Release/2.2.0.rc2

### DIFF
--- a/tools/add_rc_version.py
+++ b/tools/add_rc_version.py
@@ -1,3 +1,3 @@
 from abejacli.version import VERSION
 
-print("{}rc1".format(VERSION), end="")
+print("{}rc2".format(VERSION), end="")


### PR DESCRIPTION
## これは何
↓のプルリクが失敗した（https://pypi.org/help/#file-name-reuse ）ので、rc2としてプレリリースします。
https://github.com/abeja-inc/abeja-platform-cli/pull/48

## 備考
`tools/add_rc_version.py` はこのマージ後に戻します。