### PR TITLE
【DX テンプレート一覧】abeja-platform-cli の init コマンド修正

### DIFF
--- a/abejacli/dx_template/commands.py
+++ b/abejacli/dx_template/commands.py
@@ -17,7 +17,7 @@ from abejacli.configuration import __ensure_configuration_exists
 from abejacli.logger import get_logger
 from abejacli.session import generate_user_session
 
-DX_TEMPLATE_SKELETON_REPO = 'https://github.com/abeja-inc/platform-dx-template-samples.git'
+DX_TEMPLATE_SKELETON_REPO = 'https://github.com/abeja-inc/platform-dx-template-skeleton-v1.git'
 
 logger = get_logger()
 

--- a/abejacli/dx_template/commands.py
+++ b/abejacli/dx_template/commands.py
@@ -8,7 +8,6 @@ import zipfile
 import click
 import yaml
 
-from abejacli.common import __try_get_organization_id
 from abejacli.config import (
     ERROR_EXITCODE,
     ORGANIZATION_ENDPOINT,
@@ -35,20 +34,13 @@ def dx_template(ctx):
 @dx_template.command(name='init', help='Prepare and create your own DX template definition files')
 @click.option('-n', '--name', 'name', prompt='Please enter your DX template name', type=str, required=False,
               help='DX template name')
-@click.option('-o', '--organization_id', '--organization-id', 'organization_id', type=str, required=False,
-              help='Organization ID, organization_id of current credential organization is used by default. '
-                   'This value is set as an environment variable named `ABEJA_ORGANIZATION_ID`. '
-                   '`ABEJA_ORGANIZATION_ID` from this arg takes priority over one in `--environment`.',
-              callback=__try_get_organization_id)
-@click.option('-s', '--skeleton_file', '--skeleton-file', 'skeleton_file', type=click.Choice(['Y', 'n']), default='Y',
-              prompt='want DX template definition skeleton files?',
-              help='get (or not get) skeleton files')
-def init(name, organization_id, skeleton_file):
+def init(name):
     """dx-template init コマンド
+    DX テンプレート開発者に開発環境を提供するコマンド。
+    git hub で管理しているDX テンプレート用のskeleton ファイルを元に各種定義ファイルを用意する。
+
     Args:
         name(str) : DX テンプレート名
-        organization_id(str) : オーガニゼーションID
-        skeleton_file(str) : skeleton ファイルの要否（Y or n）
     """
     click.echo('\n==== Your Settings ============================')
 
@@ -57,10 +49,7 @@ def init(name, organization_id, skeleton_file):
     click.echo(f'DX Template name: {name}')
 
     # DX テンプレートのサンプルファイル取得要否
-    if skeleton_file == 'Y':
-        click.echo(f'Download the skeleton file from {DX_TEMPLATE_SKELETON_REPO}.')
-    else:
-        click.echo('Skeleton files will not be downloaded.')
+    click.echo(f'Download the skeleton file from {DX_TEMPLATE_SKELETON_REPO}.')
 
     # Future Work: 公開/非公開設定
     click.echo('This DX template is used only inside your organization.')
@@ -78,9 +67,7 @@ def init(name, organization_id, skeleton_file):
         click.echo('Aborted!')
         sys.exit(ERROR_EXITCODE)
 
-    # skeleton ファイルの取得と保存
-    if skeleton_file == 'Y':
-        git_clone_skeleton_files(DX_TEMPLATE_SKELETON_REPO, name)
+    git_clone_skeleton_files(DX_TEMPLATE_SKELETON_REPO, name)
 
     # template.yaml の更新
     update_template_yaml(name, template_scope, abeja_user_only)
@@ -205,7 +192,7 @@ def git_clone_skeleton_files(repository_url, destination_path, git_branch='main'
     Args:
         repository_url (str): git hub リポジトリ のhttps のURL
         destination_path (str): git clone するローカルのパス
-        git_branch (str): 取得先のリポジトリのブランチ名（していなければmain）
+        git_branch (str): 取得先のリポジトリのブランチ名（指定がなければmain）
     """
     try:
         click.echo('================================')

--- a/abejacli/dx_template/commands.py
+++ b/abejacli/dx_template/commands.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import zipfile
@@ -155,7 +156,7 @@ def push(directory_path):
 
 def update_template_yaml(name, template_scope='private', abeja_user_only=True):
     """引数で渡された内容をもとにtemplate.yaml を更新する
-    template.yaml は`./{name}/template.yml` に配置されていることを想定している
+    template.yaml は`./{name}/template.yaml` に配置されていることを想定している
 
     Args:
         name (str): DX テンプレート名
@@ -163,11 +164,15 @@ def update_template_yaml(name, template_scope='private', abeja_user_only=True):
         abeja_user_only (bool): ABEJA Only か否か
     """
 
-    file_path = f'./{name}/template.yaml'
+    template_yaml_path = f'./{name}/template.yaml'
+    template_usage_yaml_path = f'./{name}/templateUsage.yaml'
 
     try:
+        # 元のtemplate.yaml は上書きする時に開発者向けの説明コメントが消えてしまうので、別名保存しておく。（マニュアルがわりに使う）
+        shutil.copy(template_yaml_path, template_usage_yaml_path)
+
         # YAML ファイルを読み込み
-        with open(file_path, 'r') as file:
+        with open(template_yaml_path, 'r') as file:
             data = yaml.safe_load(file)
 
         # 内容を編集
@@ -176,7 +181,7 @@ def update_template_yaml(name, template_scope='private', abeja_user_only=True):
         data['metadata']['abejaUserOnly'] = abeja_user_only
 
         # 編集後の内容をYAMLファイルに書き込み
-        with open(file_path, 'w') as file:
+        with open(template_yaml_path, 'w') as file:
             yaml.dump(data, file)
 
     except yaml.YAMLError as e:

--- a/abejacli/dx_template/commands.py
+++ b/abejacli/dx_template/commands.py
@@ -1,7 +1,6 @@
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
 import zipfile
@@ -165,12 +164,8 @@ def update_template_yaml(name, template_scope='private', abeja_user_only=True):
     """
 
     template_yaml_path = f'./{name}/template.yaml'
-    template_usage_yaml_path = f'./{name}/templateUsage.yaml'
 
     try:
-        # 元のtemplate.yaml は上書きする時に開発者向けの説明コメントが消えてしまうので、別名保存しておく。（マニュアルがわりに使う）
-        shutil.copy(template_yaml_path, template_usage_yaml_path)
-
         # YAML ファイルを読み込み
         with open(template_yaml_path, 'r') as file:
             data = yaml.safe_load(file)


### PR DESCRIPTION
## これは何
- template.yaml のフォーマット変更に伴うinit コマンドのロジック変更を行いました。
    - フォーマット変更とともに、template.yaml はskeleton のリポジトリに保存される形になったので、その変更への追従も同時に実施

## やったこと
- `https://github.com/abeja-inc/platform-dx-template-samples.git` からのファイルダウンロード要否の選択を無くして必ずダウンロードされるように変更
- template.yaml を上記skeleton リポジトリに格納されているものをベースにユーザ入力値を反映させて作成されるように変更
- skeleton リポジトリのURL 変更


## 確認したこと
- init コマンド実行してskeleton ダウンロードの有無を聞かれることなくファイルが手元に配置されることを確認

## 備考
- template.yaml が複数あることでDX テンプレート開発者に混乱を招く恐れがあるため、以下の対処は削除しました。
    - ~処理の中でtemplate.yaml はユーザ入力値で上書きしますが、yaml ライブラリの仕様上、コメントが消えてしまうので、更新前のtemplate.yaml を`templateUsage.yaml` というファイル名で別名保存するようにしています。（開発者向けのコメントがマニュアルがわりに使えそうだから）~