### PR TITLE
Valid template.yaml in dxtemplate push command

### DIFF
--- a/abejacli/dx_template/commands.py
+++ b/abejacli/dx_template/commands.py
@@ -269,6 +269,7 @@ def files_and_directorys_to_zip(directory_path, zip_path):
                 rel_path = os.path.relpath(dir_path, directory_path)
                 zipf.write(dir_path, rel_path)
 
+
 def verify_dxtemplate_yaml(template_yaml, template_schema):
     try:
         schema = yamale.make_schema(template_schema)

--- a/abejacli/dx_template/commands.py
+++ b/abejacli/dx_template/commands.py
@@ -7,6 +7,7 @@ import zipfile
 
 import click
 import ruamel.yaml
+import yamale
 from PIL import Image
 
 from abejacli.config import (
@@ -112,6 +113,10 @@ def push(directory_path):
             click.echo(f'A required file is missing: {path}')
             sys.exit(ERROR_EXITCODE)
 
+    # template.yaml のフォーマットを確認する
+    template_schema = os.path.join(directory_path, 'template_schema.yaml')
+    verify_dxtemplate_yaml(upload_files["template_yaml"], template_schema)
+
     # Thumbnail.jpg の解像度を確認する
     thumbnail_img = Image.open(upload_files["thumbnail"])
     if thumbnail_img.width > DX_TEMPLATE_THUMBNAIL_WIDTH_MAX or thumbnail_img.height > DX_TEMPLATE_THUMBNAIL_HEIGHT_MAX:
@@ -165,7 +170,7 @@ def push(directory_path):
         click.echo(json.dumps(content, indent=4))
 
     except Exception as e:
-        click.echo('Error: Failed to upload {} to DX template repository (Reason: {})'.format(file_path, e))
+        click.echo('Error: Failed to upload files {} to DX template repository (Reason: {})'.format(upload_files, e))
         sys.exit(ERROR_EXITCODE)
     finally:
         # io.BufferedReader を全てclose する
@@ -263,3 +268,16 @@ def files_and_directorys_to_zip(directory_path, zip_path):
                 dir_path = os.path.join(root, d)
                 rel_path = os.path.relpath(dir_path, directory_path)
                 zipf.write(dir_path, rel_path)
+
+def verify_dxtemplate_yaml(template_yaml, template_schema):
+    try:
+        schema = yamale.make_schema(template_schema)
+        data = yamale.make_data(template_yaml)
+        yamale.validate(schema, data, strict=False)
+    except ValueError as e:
+        click.echo(f'Validation failed of template.yaml!: {e}\n')
+        sys.exit(ERROR_EXITCODE)
+    except Exception as e:
+        click.echo(f'Exception was occurred!: {e}\n')
+        sys.exit(ERROR_EXITCODE)
+    return

--- a/poetry.lock
+++ b/poetry.lock
@@ -864,7 +864,7 @@ six = ">=1.5"
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -1261,7 +1261,22 @@ files = [
     {file = "wrapt-1.15.0.tar.gz", hash = "sha256:d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a"},
 ]
 
+[[package]]
+name = "yamale"
+version = "4.0.4"
+description = "A schema and validator for YAML."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "yamale-4.0.4-py3-none-any.whl", hash = "sha256:04f914c0886bda03ac20f8468272cfd9374a634a062549490eff2beedeb30497"},
+    {file = "yamale-4.0.4.tar.gz", hash = "sha256:e524caf71cbbbd15aa295e8bdda01688ac4b5edaf38dd60851ddff6baef383ba"},
+]
+
+[package.dependencies]
+pyyaml = "*"
+
 [metadata]
 lock-version = "2.0"
 python-versions = "~=3.9"
-content-hash = "3e0e1324d776040896f54b7ab05a40855fbe8f2423afbfc36bd41e922479d74b"
+content-hash = "3d2eff6722a14b9f4546788d74d1c4e1a9db8f99e374de6874e8197c29497132"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ retrying = "~=1.3.0"
 tqdm = "~=4.15.0"
 tomlkit = "^0.5.11"
 pillow = "~=9.4.0"
+yamale = ">=4.0,<5.0"
 
 [tool.poetry.dev-dependencies]
 autoflake = "==1.4"


### PR DESCRIPTION
`dxtemplate push` コマンドでDXテンプレート登録する際に、`template.yaml` のファイルフォーマット validation 処理を追加しました。
validation 処理は Yamale を用いて、platform-dx-template-skeleton-v1 レポジトリの `[template_schema.yaml](https://github.com/abeja-inc/platform-dx-template-skeleton-v1/blob/main/template_schema.yaml)` をもとに行われます