### PR TITLE
[ABEJA Platform Labs] Add github URL in labs init command

### DIFF
--- a/abejacli/labs/commands.py
+++ b/abejacli/labs/commands.py
@@ -228,19 +228,24 @@ def update_setting_yaml(name, scope='private', abeja_user_only=True, auth_type='
 
     setting_yaml_path = f'./{name}/setting.yaml'
 
+
     try:
         # YAML ファイルを読み込み
         yaml = ruamel.yaml.YAML()
         with open(setting_yaml_path, 'r') as file:
             data = yaml.load(file)
 
-        # 内容を編集
+        # 内容を編集（必須項目）
         data['metadata']['name'] = name
         data['metadata']['scope'] = scope
         data['metadata']['abejaUserOnly'] = abeja_user_only
         data['metadata']['authType'] = auth_type
         data['metadata']['author'] = author
         data['spec']['image'] = f'{name}:latest'
+
+        # 内容を編集（オプション項目）
+        if 'githubURL' in data['metadata']:
+            data['metadata']['githubURL'] = f'https://github.com/abeja-inc/{name}'
 
         # 編集後の内容をYAMLファイルに書き込み
         with open(setting_yaml_path, 'w') as file:

--- a/abejacli/labs/commands.py
+++ b/abejacli/labs/commands.py
@@ -228,7 +228,6 @@ def update_setting_yaml(name, scope='private', abeja_user_only=True, auth_type='
 
     setting_yaml_path = f'./{name}/setting.yaml'
 
-
     try:
         # YAML ファイルを読み込み
         yaml = ruamel.yaml.YAML()

--- a/tests/unit/labs/commands_test.py
+++ b/tests/unit/labs/commands_test.py
@@ -27,6 +27,7 @@ LABS_APP_SCOPE = 'private'
 LABS_APP_ABEJA_USER_ONLY = True
 LABS_APP_AUTH_TYPE = 'abeja'
 LABS_APP_AUTHOR = 'test@abejainc.com'
+LABS_APP_GITHUB_URL = 'https://github.com/abeja-inc/platform-labs-app-skeleton-v1'
 
 MOCK_LABS_APP_RESPONSE = {
     "labs_app_id": "1111111111111",
@@ -39,6 +40,7 @@ MOCK_LABS_APP_RESPONSE = {
     "abeja_user_only": LABS_APP_ABEJA_USER_ONLY,
     "author": LABS_APP_AUTHOR,
     "auth_type": LABS_APP_AUTH_TYPE,
+    "github_url": LABS_APP_GITHUB_URL,
     "image": f"custom/1111111111111/${LABS_APP_NAME_PUSH}:latest",
     "instance_type": "cpu-0.25",
     "command": "python3 -m http.server 8501 -d /app/src",


### PR DESCRIPTION
`abeja labs init` コマンド実行時に、Labs アプリ設定ファイル `setting.yaml` の GitHub レポジトリ URL を Labs アプリ名で上書きするようにしました