### PR TITLE
[Labs] Add labs commands to overwrite app

### DIFF
--- a/abejacli/labs/commands.py
+++ b/abejacli/labs/commands.py
@@ -318,7 +318,7 @@ def delete(labs_app_id, yes):
     except Exception as e:
         click.echo('Error: Failed to delete LabsApp (Reason: {})'.format(e))
         sys.exit(ERROR_EXITCODE)
-    
+
     # 処理正常終了
     click.echo(f'Delete succeeded')
     sys.exit(SUCCESS_EXITCODE)

--- a/abejacli/labs/commands.py
+++ b/abejacli/labs/commands.py
@@ -237,7 +237,7 @@ def push(directory_path, stop_after, yes):
 
         # 上書きの場合は、Labs アプリ更新 API を呼び出す
         if not yes and overwrite_app is not None:
-            url = f"{ORGANIZATION_ENDPOINT.replace('organizations', 'labs/organizations')}/apps/{overwrite_app["labs_app_id"]}?stop_after={stop_after}"
+            url = f"{ORGANIZATION_ENDPOINT.replace('organizations', 'labs/organizations')}/apps/{overwrite_app['labs_app_id']}?stop_after={stop_after}"
             with generate_user_session(False) as session:
                 response = session.put(url, files=files, timeout=None)
         # 上書きでない場合は、Labs アプリ作成 API を呼び出す

--- a/abejacli/labs/commands.py
+++ b/abejacli/labs/commands.py
@@ -187,7 +187,7 @@ def push(directory_path, stop_after, yes):
         sys.exit(ERROR_EXITCODE)
 
     # 同じ名前の LabsApp が存在するか確認する
-    overwrite = False
+    overwrite_app = None
     if not yes:
         same_name_apps = []
         try:
@@ -215,9 +215,9 @@ def push(directory_path, stop_after, yes):
                 )
             answer = click.prompt('Please enter the number you want to overwrite LabsApp.', type=int, default=0)
             if answer == 0:
-                overwrite = False
+                overwrite_app = None
             elif 0 < answer <= len(same_name_apps):
-                overwrite = True
+                overwrite_app = same_name_apps[answer - 1]
             else:
                 click.echo('Invalid number. Aborted.')
                 sys.exit(ERROR_EXITCODE)
@@ -235,13 +235,12 @@ def push(directory_path, stop_after, yes):
             else:
                 files.append((file_name, (os.path.basename(file_path), file, 'text/markdown')))
 
-        # 上書きの場合は、Labs アプリ再登録 API を呼び出す
-        if not yes and overwrite:
-            # TODO: change URL and method
-            url = f"{ORGANIZATION_ENDPOINT.replace('organizations', 'labs/organizations')}/apps?stop_after={stop_after}"
+        # 上書きの場合は、Labs アプリ更新 API を呼び出す
+        if not yes and overwrite_app is not None:
+            url = f"{ORGANIZATION_ENDPOINT.replace('organizations', 'labs/organizations')}/apps/{overwrite_app["labs_app_id"]}?stop_after={stop_after}"
             with generate_user_session(False) as session:
-                response = session.post(url, files=files, timeout=None)
-        # 上書きでない場合は、Labs アプリ登録 API を呼び出す
+                response = session.put(url, files=files, timeout=None)
+        # 上書きでない場合は、Labs アプリ作成 API を呼び出す
         else:
             url = f"{ORGANIZATION_ENDPOINT.replace('organizations', 'labs/organizations')}/apps?stop_after={stop_after}"
             with generate_user_session(False) as session:

--- a/abejacli/labs/commands.py
+++ b/abejacli/labs/commands.py
@@ -203,10 +203,16 @@ def push(directory_path, stop_after, yes):
             sys.exit(ERROR_EXITCODE)
 
         if len(same_name_apps) > 0:
-            click.echo(f'The same name LabsApps are found. Select LabsApp to overwrite.')
+            click.echo('The same name LabsApps are found. Select LabsApp to overwrite.')
             click.echo('0: Do not overwrite')
             for i, app in enumerate(same_name_apps):
-                click.echo(f'{i+1}: id:{app["labs_app_id"]}, name:{app["name"]}, version:{app["version"]}, author:{app["author"]}, created_at:{app["created_at"]}')
+                click.echo(
+                    f'{i+1}: id:{app["labs_app_id"]}, '
+                    f'name:{app["name"]}, '
+                    f'version:{app["version"]}, '
+                    f'author:{app["author"]}, '
+                    f'created_at:{app["created_at"]}'
+                )
             answer = click.prompt('Please enter the number you want to overwrite LabsApp.', type=int, default=0)
             if answer == 0:
                 overwrite = False

--- a/abejacli/labs/commands.py
+++ b/abejacli/labs/commands.py
@@ -212,6 +212,7 @@ def push(directory_path, stop_after, yes):
                     f'    - version: {app["version"]}\n'
                     f'    - author: {app["author"]}\n'
                     f'    - created at: {app["created_at"]}\n'
+                    f'    - modified at: {app["modified_at"]}\n'
                 )
             answer = click.prompt(
                 '\nPlease enter the number you want to overwrite LabsApp',
@@ -241,6 +242,7 @@ def push(directory_path, stop_after, yes):
 
         # 上書きの場合は、Labs アプリ更新 API を呼び出す
         if not yes and overwrite_app is not None:
+            click.echo(f'Overwriting LabsApp. Please wait for a while...')
             url = f"{ORGANIZATION_ENDPOINT.replace('organizations', 'labs/organizations')}/apps/{overwrite_app['labs_app_id']}?stop_after={stop_after}"
             with generate_user_session(False) as session:
                 response = session.put(url, files=files, timeout=None)
@@ -296,7 +298,8 @@ def delete(labs_app_id, yes):
             f'  - description: {labs_app["description"]}\n'
             f'  - version: {labs_app["version"]}\n'
             f'  - author: {labs_app["author"]}\n'
-            f'  - created_at: {labs_app["created_at"]}'
+            f'  - created_at: {labs_app["created_at"]} \n'
+            f'  - modified_at: {labs_app["modified_at"]}'
         )
         answer = click.prompt(
             message,

--- a/abejacli/labs/commands.py
+++ b/abejacli/labs/commands.py
@@ -127,7 +127,6 @@ def init(name, app_type, scope, abeja_user_only, auth_type, author):
     sys.exit(SUCCESS_EXITCODE)
 
 
-# type 引数で渡しているclick.Path指定されたパスが実際に存在するかどうかを検証する
 @labs.command(name='push', help='Upload your own Labs App definition files')
 @click.option('-d', '--directory_path', 'directory_path', type=click.Path(exists=True, file_okay=False),
               help='Directory path where your own Labs App definition file is located. '
@@ -135,8 +134,7 @@ def init(name, app_type, scope, abeja_user_only, auth_type, author):
               default=None, required=True)
 @click.option('-s', '--stop_after', 'stop_after', type=int, default=0, required=False,
               help='Labs App stop automatically after the specified number of hours')
-@click.option('-y', '--yes', 'yes', type=bool, default=False, required=False,
-              help='Skip the confirmation prompt and overwrite the existing Labs App')
+@click.option('-y', '--yes', 'yes', is_flag=True, default=False, help='Skip the confirmation prompt')
 def push(directory_path, stop_after, yes):
     """labs push コマンド
     ローカルで作成した Labs アプリ定義ファイルを ABEJA Platform にアップロードする
@@ -203,17 +201,23 @@ def push(directory_path, stop_after, yes):
             sys.exit(ERROR_EXITCODE)
 
         if len(same_name_apps) > 0:
-            click.echo('The same name LabsApps are found. Select LabsApp to overwrite.')
-            click.echo('0: Do not overwrite')
+            click.echo('\nThe same name LabsApps are found. Select LabsApp to overwrite.\n')
+            click.echo('  0: Do not overwrite. Create new LabApp\n')
             for i, app in enumerate(same_name_apps):
                 click.echo(
-                    f'{i+1}: id:{app["labs_app_id"]}, '
-                    f'name:{app["name"]}, '
-                    f'version:{app["version"]}, '
-                    f'author:{app["author"]}, '
-                    f'created_at:{app["created_at"]}'
+                    f'  {i+1}: LabsApp Details\n'
+                    f'    - id: {app["labs_app_id"]}\n'
+                    f'    - name: {app["name"]}\n'
+                    f'    - description: {app["description"]}\n'
+                    f'    - version: {app["version"]}\n'
+                    f'    - author: {app["author"]}\n'
+                    f'    - created at: {app["created_at"]}\n'
                 )
-            answer = click.prompt('Please enter the number you want to overwrite LabsApp.', type=int, default=0)
+            answer = click.prompt(
+                '\nPlease enter the number you want to overwrite LabsApp',
+                type=int,
+                default=0
+            )
             if answer == 0:
                 overwrite_app = None
             elif 0 < answer <= len(same_name_apps):

--- a/abejacli/labs/commands.py
+++ b/abejacli/labs/commands.py
@@ -320,7 +320,7 @@ def delete(labs_app_id, yes):
         sys.exit(ERROR_EXITCODE)
 
     # 処理正常終了
-    click.echo(f'Delete succeeded')
+    click.echo('Delete succeeded')
     sys.exit(SUCCESS_EXITCODE)
 
 

--- a/abejacli/labs/commands.py
+++ b/abejacli/labs/commands.py
@@ -242,7 +242,7 @@ def push(directory_path, stop_after, yes):
 
         # 上書きの場合は、Labs アプリ更新 API を呼び出す
         if not yes and overwrite_app is not None:
-            click.echo(f'Overwriting LabsApp. Please wait for a while...')
+            click.echo('Overwriting LabsApp. Please wait for a while...')
             url = f"{ORGANIZATION_ENDPOINT.replace('organizations', 'labs/organizations')}/apps/{overwrite_app['labs_app_id']}?stop_after={stop_after}"
             with generate_user_session(False) as session:
                 response = session.put(url, files=files, timeout=None)


### PR DESCRIPTION
APF Labs の上書き登録用の各種コマンドを追加しました

- Labs アプリ作成コマンド（`abeja labs push`）にて、同名 Labs アプリを上書き登録できるようにしました
- Labs アプリ上書き登録コマンド（`abeja labs update`）を追加しました
- Labs アプリ削除コマンド（`abeja labs delete`）を追加しました