### PR TITLE
Change release strategy from git-flow to PR-based workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - run:
           name: Deploy_RC
           command: |
-            poetry version $(PYTHONPATH=./ poetry run python tools/add_rc_version.py)
+            poetry version $(PYTHONPATH=./ poetry run python tools/get_next_rc_version.py)
             make release
 workflows:
   version: 2
@@ -93,6 +93,6 @@ workflows:
           filters:
             branches:
               only:
-                - /^release\/.*/
+                - staging
           requires:
             - codetest39

--- a/.github/workflows/auto-tag-on-release.yml
+++ b/.github/workflows/auto-tag-on-release.yml
@@ -1,0 +1,55 @@
+name: Auto Tag on Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from pyproject.toml
+        id: get_version
+        run: |
+          VERSION=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          if git rev-parse "refs/tags/${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag ${{ steps.get_version.outputs.version }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag ${{ steps.get_version.outputs.version }} does not exist"
+          fi
+
+      - name: Create and push tag
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ steps.get_version.outputs.version }}
+          git push origin ${{ steps.get_version.outputs.version }}
+          echo "✅ Created and pushed tag: ${{ steps.get_version.outputs.version }}"
+
+      - name: Create GitHub Release
+        if: steps.check_tag.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.version }}
+          name: Release ${{ steps.get_version.outputs.version }}
+          body: |
+            Release ${{ steps.get_version.outputs.version }}
+            See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/master/CHANGELOG.md) for details.
+          draft: false
+          prerelease: false
+

--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
       - master
-      - release/*
+      - staging
 
 jobs:
   ci:
@@ -76,7 +76,7 @@ jobs:
 
   cd:
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref_name, 'release/') || github.ref_name == 'master' }}
+    if: ${{ github.ref_name == 'staging' || github.ref_name == 'master' }}
     needs:
       - ci
 
@@ -96,9 +96,9 @@ jobs:
           poetry install
 
       - name: Deploy_RC
-        if: ${{ startsWith(github.ref_name, 'release/') }}
+        if: ${{ github.ref_name == 'staging' }}
         run: |
-          poetry version $(PYTHONPATH=./ poetry run python tools/add_rc_version.py)
+          poetry version $(PYTHONPATH=./ poetry run python tools/get_next_rc_version.py)
           make release
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.8
+- Change release strategy from git-flow to PR-based workflow
+
 # 2.2.7
 - [APF SecretManager] Add integration service in labs cli #65
 - 【APF SecretManager】APF CLI からセキュアに利用できるようにする #64

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ $ poetry install
 # configure pre-commit
 $ poetry run pre-commit install
 
-# install git-flow
-$ brew install git-flow-avh # for macOS
-$ apt-get install git-flow # for Linux
 ```
 
 ## Run command locally
@@ -34,42 +31,28 @@ $ make test
 ```
 
 ## Release
-Synchronize master and develop branch.
 
-```bash
-$ git checkout master
-$ git pull
-$ git checkout develop
-$ git pull
-```
+### Deploy to Development Environment
 
-Create release branch and prepare for release.
+When creating a PR from `feature/xxx` to `develop` branch, include version updates in the PR:
+- Update `CHANGELOG.md`: Add your changes to the latest version section (do not create a new version section if the current version hasn't been released to staging yet)
+- Update `pyproject.toml` version (e.g., `2.2.7` → `2.2.8`)
 
-```bash
-$ git flow release start X.X.X
-$ vim CHANGELOG.md
-# update to new version
-$ poetry version X.X.X
-# If you want to set rc2, rc3, ... versions, you need to edit add_rc_version.
-$ vim tools/add_rc_version.py
-$ git add pyproject.toml
-$ git add CHANGELOG.md
-$ git add tools/add_rc_version.py
-$ git commit -m "bump version"
-$ git flow release publish X.X.X
-```
+> **Note**: If the current version in `pyproject.toml` has never been released to staging, you don't need to create a new version section in `CHANGELOG.md` or update `pyproject.toml`. Instead, add your changes to the existing latest version section in `CHANGELOG.md`. Only create a new version section and update `pyproject.toml` when the previous version has been released to staging. Alternatively, update the version only when creating a PR to `staging` to avoid version gaps in PyPI releases.
 
-After pushing to relase branch, RC package is published to packagecloud.
+Then create a PR and merge from `feature/xxx` to `develop` branch.
 
-Check CircleCI result.
-If the build succeeded then execute:
+### Deploy to Staging Environment
 
-```bash
-$ git flow release finish X.X.X
-$ git push origin develop
-$ git push origin master
-$ git push origin X.X.X
-```
+Create a PR and merge from `develop` to `staging` branch.
+
+After pushing to staging branch, RC package is automatically published to PyPI with the next available RC version (e.g., `2.2.8rc1`, `2.2.8rc2`, ...). The RC version number is automatically determined by querying PyPI for existing RC versions.
+
+### Deploy to Production Environment
+
+Create a PR and merge from `staging` to `master` branch.
+
+After pushing to master branch, the final package (e.g., `2.2.8`) is published to PyPI.
 
 ## Environment Vars
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "abejacli"
-version = "2.2.7"
+version = "2.2.8"
 description = "ABEJA Platform Command line tool"
 authors = ["ABEJA Inc. <platform-support@abejainc.com>"]
 classifiers = [

--- a/tools/add_rc_version.py
+++ b/tools/add_rc_version.py
@@ -1,3 +1,0 @@
-from abejacli.version import VERSION
-
-print("{}rc2".format(VERSION), end="")

--- a/tools/get_next_rc_version.py
+++ b/tools/get_next_rc_version.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Get the next RC version number for the current version in pyproject.toml.
+
+This script:
+1. Reads the current version from pyproject.toml
+2. Queries PyPI API to find existing RC versions for that version
+3. Returns the next RC version (e.g., if 2.2.8rc1 and 2.2.8rc2 exist, returns 2.2.8rc3)
+"""
+
+import json
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+
+def get_version_from_pyproject():
+    """Extract version from pyproject.toml"""
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    with open(pyproject_path, "r") as f:
+        for line in f:
+            if line.strip().startswith("version ="):
+                # Extract version from: version = "2.2.8"
+                match = re.search(r'version\s*=\s*"([^"]+)"', line)
+                if match:
+                    return match.group(1)
+    raise ValueError("Could not find version in pyproject.toml")
+
+
+def get_pypi_versions(package_name="abejacli"):
+    """Get all versions from PyPI"""
+    url = f"https://pypi.org/pypi/{package_name}/json"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as response:
+            data = json.loads(response.read())
+            return list(data.get("releases", {}).keys())
+    except Exception as e:
+        print(f"Warning: Could not fetch versions from PyPI: {e}", file=sys.stderr)
+        return []
+
+
+def get_next_rc_version(base_version, existing_versions):
+    """Find the next RC version number"""
+    # Filter versions that match the base version with rc suffix
+    rc_pattern = re.compile(rf"^{re.escape(base_version)}rc(\d+)$")
+    rc_numbers = []
+
+    for version in existing_versions:
+        match = rc_pattern.match(version)
+        if match:
+            rc_numbers.append(int(match.group(1)))
+
+    if rc_numbers:
+        next_rc = max(rc_numbers) + 1
+    else:
+        next_rc = 1
+
+    return f"{base_version}rc{next_rc}"
+
+
+def main():
+    try:
+        base_version = get_version_from_pyproject()
+        existing_versions = get_pypi_versions()
+        next_rc_version = get_next_rc_version(base_version, existing_versions)
+        print(next_rc_version, end="")
+        return 0
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 概要
git-flowベースのリリース戦略をPRベースのワークフローに変更しました。

## 変更内容

### 1. README.md
- git-flowのリリース手順を削除
- PRベースのワークフローに変更
  - Dev環境: `feature/xxx` → `develop` (PR)
  - Staging環境: `develop` → `staging` (PR)
  - Production環境: `staging` → `master` (PR)
- バージョン更新のタイミングと注意事項を追加

### 2. .circleci/config.yml
- staging環境のRCパッケージリリーストリガーを`/^release\/.*/`から`staging`ブランチに変更

### 3. .github/workflows/cli.yaml
- `push`トリガーに`release/*`を追加していた部分を`staging`に変更
- `cd`ジョブの条件を`startsWith(github.ref_name, 'release/')`から`github.ref_name == 'staging'`に変更
- `Deploy_RC`ステップの条件を`startsWith(github.ref_name, 'release/')`から`github.ref_name == 'staging'`に変更

### 4. CHANGELOG.md
- バージョン2.2.8のエントリを追加
- 「Change release strategy from git-flow to PR-based workflow」を記録

### 5. pyproject.toml
- バージョンを2.2.7から2.2.8に更新

### 6. tools/get_next_rc_version.py (新規作成)
- `add_rc_version.py`を廃止し、PyPI APIから既存のRCバージョンを確認して次のRC番号を自動決定するスクリプトを作成
- stagingブランチへのマージ時に自動で`rc1`, `rc2`, `rc3`...の順番でバージョンが生成される

### 7. tools/add_rc_version.py
- 削除（廃止）

### 8. .github/workflows/auto-tag-on-release.yml (新規作成)
- `master`ブランチへのマージ時に自動でGitタグとGitHub Releaseを作成
- `pyproject.toml`からバージョンを取得
- `actions/checkout@v4`を使用

## 参考
- model_api PR #1179と同様の変更
- datalake PR #613と同様の変更
- platform-dataset-api PR #101と同様の変更
- platform-agent PR #195と同様の変更