### PR TITLE
Pin release workflow Poetry version

### DIFF
--- a/.github/workflows/cli.yaml
+++ b/.github/workflows/cli.yaml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install --user poetry
+          pip install --user poetry~=1.5.1
           poetry install
 
       - name: Deploy_RC


### PR DESCRIPTION
## Summary

Release jobで利用するPoetry versionを、CI jobと同じ `~1.5.1` に固定します。

## Why

PR #71 でCI/CD workflowをCircleCI移行向けに整理しましたが、`cd` jobだけ `pip install --user poetry` のままで、実行時点の最新Poetryに依存していました。staging / master release前にCI側と揃えて、release時の差分を減らします。

## Changes

- `.github/workflows/cli.yaml` の `cd` jobで `poetry~=1.5.1` をinstallするよう変更

## Test

- [x] `git diff --check`
- [x] YAML parse確認

## Related

Refs #70
Follow-up to #71
